### PR TITLE
fix slime chunks algorithm

### DIFF
--- a/src/main/java/com/github/lunatrius/core/world/chunk/ChunkHelper.java
+++ b/src/main/java/com/github/lunatrius/core/world/chunk/ChunkHelper.java
@@ -7,7 +7,10 @@ public class ChunkHelper {
     private static final Random RANDOM = new Random();
 
     public static boolean isSlimeChunk(long seed, int x, int z) {
-        RANDOM.setSeed(seed + (x * x * 4987142) + (x * 5947611) + (z * z * 4392871) + (z * 389711) ^ 987234911);
+        // noinspection IntegerMultiplicationImplicitCastToLong - we want to do the casts as integers and *then* cast
+        RANDOM.setSeed(
+            seed + (long) (x * x * 0x4c1906) + (long) (x * 0x5ac0db) + (long) (z * z) * 0x4307a7L + (long) (z * 0x5f24f)
+                ^ 0x3ad8025fL);
         return RANDOM.nextInt(10) == 0;
     }
 }


### PR DESCRIPTION
The old algorithm was incorrectly using integer literals in two places instead of long literals.  This caused it to incorrectly handle certain seeds.  I also took the liberty of making the code exactly match the reference implementation on the wiki using hex literals and casts, just to be sure it was completely identical.